### PR TITLE
Revamp README for clearer project presentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.idea/
+.vscode/
+
+# Python
+__pycache__/
+*.pyc
+
+# Notebooks
+.ipynb_checkpoints/
+
+# Local outputs (keep tracked if you want them versioned)
+output_eval.txt

--- a/README.md
+++ b/README.md
@@ -1,51 +1,95 @@
-# COMP6247-Maze
-Reinforcement Learning Project
+# Dynamic Maze Q-Learning (COMP6247)
 
-Here, a Tabular Q-Learning reinforcement learning algorithm is used to solve a dynamic maze pathfinding problem using only local information. Python file environment.py contains the developed code used for determining the shortest path to the end of the maze.
+Tabular **Q-learning** agent that learns to solve a **dynamic maze** using only local information.
+This repo contains the environment, training/evaluation code, and plots showing learning progress.
 
-## Usage
+## TL;DR
 
-Clone the repository and setup the conda environment to run the code:
+- **Method:** tabular Q-learning (ε-greedy), discrete actions (up/left/right/down)
+- **Task:** reach the goal in a dynamic maze with penalties for walls / revisits (and optional hazards)
+- **Best entry point:** `DynamicMazeQLearning.ipynb`
+
+## Results
+
+During training, the repo logs per-episode metrics and saves plots:
+
+- Total reward per episode
+- Walls hit per episode
+- Visited states per episode
+
+<p float="left">
+  <img src="total_rewards_plot.png" width="320" />
+  <img src="total_walls_hit_plot.png" width="320" />
+  <img src="total_visited_states_plot.png" width="320" />
+</p>
+
+Example path progression snapshots:
+
+<p float="left">
+  <img src="1_33595.png" width="260" />
+  <img src="2_5996.png" width="260" />
+  <img src="3_3584.png" width="260" />
+</p>
+
+## Repository structure
+
+- `environment.py` — dynamic maze environment + Q-learning logic
+- `DynamicMazeQLearning.ipynb` — notebook walkthrough (recommended)
+- `main.py` — script entrypoint (see notes below)
+- `requirements.txt` — dependencies
+- `q_table.pt` — saved Q-table after training
+- `Output.txt`, `testing_output.txt` — state transitions recorded during runs
+- `COMP6247CW-20212022.pdf` — coursework brief / problem statement
+
+## Setup
+
+### Option A — run the notebook (recommended)
+
+```bash
+pip install -r requirements.txt
+jupyter notebook
+# open DynamicMazeQLearning.ipynb
 ```
-cd <path_to_COMP6247_Maze>
-conda create --name <env> --file requirements.txt
-conda activate <env>
-```
 
-To run the code:
-```
+### Option B — run the script
+
+```bash
+pip install -r requirements.txt
 python main.py
 ```
 
-Alternatively you can open the DynamicMazeQLearning.ipynb file in Jupyter Notebook or Google Colab
+> Note: the notebook is the most reliable way to reproduce the results.
+> If `main.py` errors in your environment, use the notebook.
 
-If you want to skip the testing function, change the following line in main.py
-```
+## Training vs evaluation
+
+The typical workflow is:
+
+1. **Train** for N episodes → saves `q_table.pt` and plots
+2. **Evaluate** using the saved Q-table
+
+In `main.py`, training is currently triggered with:
+
+```python
 train(6)
-to 
-test(<num_of_episodes>) // this will utialize the saved q_table.pt file to initialize the Q-table
 ```
 
+To evaluate using a saved table, switch to:
 
-## Graphs
+```python
+test(<num_episodes>)
+```
 
-The following plots show the rewards achieved and the amount of walls hit and visited nodes over time during training
-10 episodes of training.
+## What I’d improve next (job-readiness)
 
-<img src="total_rewards_plot.png" width="500">
-<img src="total_walls_hit_plot.png" width="500">
-<img src="total_visited_states_plot.png" width="500">
+If you want this repo to read well for ML engineer / research roles, the next upgrades are:
 
-## Outputs
+- Add a short **Problem Setup** section (state, action space, reward function)
+- Document **hyperparameters** (α, γ, ε schedule) and default values
+- Add a **Reproducibility** note (Python version, deterministic seeds if used)
+- Add a **small benchmark table** (episodes to reach goal / mean reward)
+- Add a short **"What I learned"** section (tradeoffs, failure modes)
 
-The files Output.txt and testing_output.txt represent the state transitioned during training and testing respectively
+## License
 
-## Paths
-
-The following images shows the progression of training in finding the optimal path 
-
-<img src="1_33595.png" width="500">
-<img src="2_5996.png" width="500">
-<img src="3_3584.png" width="500">
-
-
+See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -80,16 +80,6 @@ To evaluate using a saved table, switch to:
 test(<num_episodes>)
 ```
 
-## What I’d improve next (job-readiness)
-
-If you want this repo to read well for ML engineer / research roles, the next upgrades are:
-
-- Add a short **Problem Setup** section (state, action space, reward function)
-- Document **hyperparameters** (α, γ, ε schedule) and default values
-- Add a **Reproducibility** note (Python version, deterministic seeds if used)
-- Add a **small benchmark table** (episodes to reach goal / mean reward)
-- Add a short **"What I learned"** section (tradeoffs, failure modes)
-
 ## License
 
 See [LICENSE](LICENSE).


### PR DESCRIPTION
This PR revamps the README to be more recruiter-friendly (TL;DR, results, repo structure, setup, training vs eval) and adds a basic .gitignore.